### PR TITLE
refactor: DB 레벨에서 Cascade Delete 사용하도록 변경 및 연관관계 편의 메서드 생성

### DIFF
--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/question/Question.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/question/Question.java
@@ -40,7 +40,7 @@ public class Question {
     @Column(nullable = false)
     private QuestionType type;
 
-    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "question")
     @JsonIgnore
     @Builder.Default
     private List<Selection> selectionList = new ArrayList<>();

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/question/Question.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/question/Question.java
@@ -51,4 +51,13 @@ public class Question {
             this.createDate = LocalDateTime.now();
         }
     }
+
+    /**
+     * 연관관계 편의 메서드
+     * @param selection
+     */
+    public void addSelection(Selection selection) {
+        selectionList.add(selection);
+        selection.setQuestion(this);
+    }
 }

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/question/service/QuestionService.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/question/service/QuestionService.java
@@ -21,9 +21,7 @@ public class QuestionService {
 
     public Question buildAndSaveQuestion(QuestionDTO questionDTO, Survey createdSurvey) {
         Question createdQuestion = questionDTO.toEntity(createdSurvey);
-        log.info(questionDTO.toString());
-        log.info(createdQuestion.toString());
-
+        createdSurvey.addQuestion(createdQuestion);
         questionRepository.save(createdQuestion);
         return createdQuestion;
     }

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/selection/Selection.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/selection/Selection.java
@@ -38,7 +38,7 @@ public class Selection implements Persistable<SelectionId> {
     @JoinColumn(name = "ques_id", insertable = false, updatable = false)
     private Question question;
 
-    @OneToMany(mappedBy = "selection", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "selection")
     @JsonIgnore
     @Builder.Default
     private List<ObjAnswer> objAnswerList = new ArrayList<>();

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/selection/service/SelectionService.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/selection/service/SelectionService.java
@@ -22,7 +22,9 @@ public class SelectionService {
         List<Selection> selectionList = selectionDTOList.stream()
                 .map(selectionDTO -> {
                     SelectionId selectionId = new SelectionId(createdQuestion.getQuesId(), selectionDTOList.indexOf(selectionDTO));
-                    return selectionDTO.toEntity(selectionId, createdQuestion);
+                    Selection selection = selectionDTO.toEntity(selectionId, createdQuestion);
+                    createdQuestion.addSelection(selection);
+                    return selection;
                 })
                 .toList();
         selectionRepository.saveAll(selectionList);

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/survey/common/Survey.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/survey/common/Survey.java
@@ -44,12 +44,12 @@ public class Survey {
     @JoinColumn(name = "userId", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "survey", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "survey")
     @JsonIgnore
     @Builder.Default
     private List<Question> questionList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "survey", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "survey")
     @JsonIgnore
     @Builder.Default
     private List<Respond> respondList = new ArrayList<>();

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/survey/common/Survey.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/survey/common/Survey.java
@@ -54,10 +54,20 @@ public class Survey {
     @Builder.Default
     private List<Respond> respondList = new ArrayList<>();
 
+
     @PrePersist
     protected void onCreate() {
         if (this.createDate == null) {
             this.createDate = LocalDateTime.now();
         }
+    }
+
+    /**
+     * 연관관계 편의 메서드
+     * @param question
+     */
+    public void addQuestion(Question question) {
+        questionList.add(question);
+        question.setSurvey(this);
     }
 }

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/user/User.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/user/User.java
@@ -45,7 +45,7 @@ public class User {
     @Column(nullable = false)
     private String name;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "user")
     @JsonIgnore
     @Builder.Default
     private List<Respond> respondList = new ArrayList<>();


### PR DESCRIPTION
- orphanremoval 삭제
- Cascade.REMOVE 삭제
- 데이터베이스 외래키 Delete cascade 설정
- 연관 관계 편의 메서드 생성
- 설문 저장/수정 시 Survey/Question/Selection 간 연관 관계 지정하도록 수정