### PR TITLE
fix: 이메일 인증 로직 수정

### DIFF
--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/mail/service/MailService.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/mail/service/MailService.java
@@ -147,15 +147,14 @@ public class MailService {
      * 비밀번호 찾기 인증 메일
      * @param userId
      */
-    public void sendPasswordModifyAuthNumber(String userId) throws Exception {
-        User user = userService.findByUserId(userId);
+    public void sendPasswordModifyAuthCode(User user) throws Exception {
         String tempAuthCode = KeyGenerators.string().generateKey().substring(0, 8);
 
         Context context = new Context();//타임리프 템플릿에 전달할 데이터 저장하는 컨테이너
         context.setVariable("receiverName", user.getName());
         context.setVariable("tempAuthCode", tempAuthCode);
         context.setVariable("expireDate", getFormatedDate(LocalDateTime.now().plusMinutes(10)));
-        userRedisService.saveVerificationCode(userId, tempAuthCode);
+        userRedisService.saveVerificationCode(user.getUserId(), tempAuthCode);
         sendMail(context, "Survwey 비밀번호 변경 인증번호 발급", user.getEmail(), "/mail/authentication");
     }
 

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/user/dto/EmailSendDTO.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/user/dto/EmailSendDTO.java
@@ -1,0 +1,11 @@
+package mcnc.survwey.domain.user.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EmailSendDTO {
+    private String userId;
+    private String email;
+}

--- a/survwey/survwey/src/main/java/mcnc/survwey/domain/user/service/AuthService.java
+++ b/survwey/survwey/src/main/java/mcnc/survwey/domain/user/service/AuthService.java
@@ -6,11 +6,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mcnc.survwey.domain.mail.service.MailService;
 import mcnc.survwey.domain.user.User;
+import mcnc.survwey.domain.user.dto.EmailSendDTO;
 import mcnc.survwey.domain.user.dto.LoginDTO;
 import mcnc.survwey.global.exception.custom.CustomException;
 import mcnc.survwey.global.exception.custom.ErrorCode;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -52,5 +51,22 @@ public class AuthService {
     private void createUserSession(LoginDTO loginDTO, HttpServletRequest request) {
         HttpSession session = request.getSession();
         session.setAttribute(LOGIN_USER, loginDTO.getUserId());
+    }
+
+    /**
+     * 이메일이 일치하는지 확인, 전송
+     * - 요청한 이메일이 일치하는지 확인
+     * - 일치하다면 해당 이메일로 전송
+     * @param emailSendDTO
+     * @return
+     * @throws Exception
+     */
+    public boolean verifyAndSendEmail(EmailSendDTO emailSendDTO) throws Exception {
+        User user = userService.findByUserId(emailSendDTO.getUserId());
+        if(user.getEmail().equals(emailSendDTO.getEmail())) {
+            mailService.sendPasswordModifyAuthCode(user);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- 기존에는 userId를 요청 받아 전송함
- userId와 Email을 동시에 입력 받아 요청한 email이 해당 사용자의 이메일과 일치하는지 확인
- 일치하다면 이메일 전송
- 일치하지 않으면 에러 전송